### PR TITLE
Update tar node module because of security vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(options, callback) {
       // Read in the downloaded tarfile
       fs.createReadStream(gitOptions.output)
         // Explode the downloaded tarfile
-        .pipe(tar.Extract({ path: options.dest }))
+        .pipe(tar.extract({ cwd: options.dest }))
         // Handle extraction errors
         .on('error', function (er) {
           callback && callback(er);

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "git-download",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Download a remote git repository as a tar file or exploded directory",
   "main": "index.js",
   "dependencies": {
     "git-wrapper": "^0.1.1",
-    "tar": "^1.0.0",
+    "tar": "^4.4.0",
     "uuid": "^1.4.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
There's a [security vulnerability](https://nodesecurity.io/advisories/57) with the version of `tar` module being used. This pull request updates the `tar` module to the latest version and updates the API used.